### PR TITLE
create pseudo unique bookmark names and inform when creation fails

### DIFF
--- a/syncoid
+++ b/syncoid
@@ -75,6 +75,8 @@ my $mbufferoptions = "-q -s 128k -m $mbuffer_size 2>/dev/null";
 # currently using ls to check for file existence because we aren't depending on perl
 # being present on remote machines.
 my $lscmd = '/bin/ls';
+my $cutcmd = '/usr/bin/cut';
+my $cksumcmd = '/usr/bin/cksum';
 
 if (length $args{'sshcipher'}) {
 	$args{'sshcipher'} = "-c $args{'sshcipher'}";
@@ -682,11 +684,16 @@ sub syncdataset {
 		if (defined $args{'create-bookmark'}) {
 			my $bookmarkcmd;
 			my $bookmarksuffix;
+			my $bookmarksuffixcmd;
 			if ($sourcehost ne '') {
-				$bookmarksuffix = "$sshcmd $sourcehost " . escapeshellparam("$sourcesudocmd $zfscmd get guid -o value -H $sourcefsescaped\@$newsyncsnapescaped | cksum | cut -d' ' -f1)"; #I don't know how those quotes should be properly escaped in perl
+				#this is ugly and should be done inside a single ssh session instead of opening the ssh pipe twice
+				$bookmarksuffixcmd = "$sshcmd $sourcehost " . escapeshellparam("$sourcesudocmd $zfscmd get guid -o value -H $sourcefsescaped\@$newsyncsnapescaped") . " | $cksumcmd | $cutcmd -d' ' -f1";
+				#next one should be done with "open" like elsewhere but I don't know that much perl yet, this is my first editing of perl code
+				$bookmarksuffix = `$bookmarksuffixcmd`;
 				$bookmarkcmd = "$sshcmd $sourcehost " . escapeshellparam("$sourcesudocmd $zfscmd bookmark $sourcefsescaped\@$newsyncsnapescaped $sourcefsescaped\#$newsyncsnapescaped-$bookmarksuffix");
 			} else {
-				$bookmarksuffix = "$sourcesudocmd $zfscmd get guid -o value -H $sourcefsescaped\@$newsyncsnapescaped | cksum | cut -d' ' -f1";
+				$bookmarksuffixcmd = "$sourcesudocmd $zfscmd get guid -o value -H $sourcefsescaped\@$newsyncsnapescaped" . " | cksum | cut -d' ' -f1";
+				$bookmarksuffix = `$bookmarksuffixcmd`;
 				$bookmarkcmd = "$sourcesudocmd $zfscmd bookmark $sourcefsescaped\@$newsyncsnapescaped $sourcefsescaped\#$newsyncsnapescaped-$bookmarksuffix";
 			}
 			if ($debug) { print "DEBUG: $bookmarkcmd\n"; }

--- a/syncoid
+++ b/syncoid
@@ -75,8 +75,7 @@ my $mbufferoptions = "-q -s 128k -m $mbuffer_size 2>/dev/null";
 # currently using ls to check for file existence because we aren't depending on perl
 # being present on remote machines.
 my $lscmd = '/bin/ls';
-my $cutcmd = '/usr/bin/cut';
-my $cksumcmd = '/usr/bin/cksum';
+my $grepcmd = '/usr/bin/grep';
 
 if (length $args{'sshcipher'}) {
 	$args{'sshcipher'} = "-c $args{'sshcipher'}";
@@ -687,12 +686,12 @@ sub syncdataset {
 			my $bookmarksuffixcmd;
 			if ($sourcehost ne '') {
 				#this is ugly and should be done inside a single ssh session instead of opening the ssh pipe twice
-				$bookmarksuffixcmd = "$sshcmd $sourcehost " . escapeshellparam("$sourcesudocmd $zfscmd get guid -o value -H $sourcefsescaped\@$newsyncsnapescaped") . " | $cksumcmd | $cutcmd -d' ' -f1";
+				$bookmarksuffixcmd = "$sshcmd $sourcehost " . escapeshellparam("$sourcesudocmd $zfscmd get guid -o value -H $sourcefsescaped\@$newsyncsnapescaped") . " | $grepcmd -o '......\$'";
 				#next one should be done with "open" like elsewhere but I don't know that much perl yet, this is my first editing of perl code
 				$bookmarksuffix = `$bookmarksuffixcmd`;
 				$bookmarkcmd = "$sshcmd $sourcehost " . escapeshellparam("$sourcesudocmd $zfscmd bookmark $sourcefsescaped\@$newsyncsnapescaped $sourcefsescaped\#$newsyncsnapescaped-$bookmarksuffix");
 			} else {
-				$bookmarksuffixcmd = "$sourcesudocmd $zfscmd get guid -o value -H $sourcefsescaped\@$newsyncsnapescaped" . " | cksum | cut -d' ' -f1";
+				$bookmarksuffixcmd = "$sourcesudocmd $zfscmd get guid -o value -H $sourcefsescaped\@$newsyncsnapescaped" . " | $grepcmd -o '......\$'";
 				$bookmarksuffix = `$bookmarksuffixcmd`;
 				$bookmarkcmd = "$sourcesudocmd $zfscmd bookmark $sourcefsescaped\@$newsyncsnapescaped $sourcefsescaped\#$newsyncsnapescaped-$bookmarksuffix";
 			}

--- a/syncoid
+++ b/syncoid
@@ -681,16 +681,18 @@ sub syncdataset {
 	if (defined $args{'no-sync-snap'}) {
 		if (defined $args{'create-bookmark'}) {
 			my $bookmarkcmd;
+			my $bookmarksuffix;
 			if ($sourcehost ne '') {
-				$bookmarkcmd = "$sshcmd $sourcehost " . escapeshellparam("$sourcesudocmd $zfscmd bookmark $sourcefsescaped\@$newsyncsnapescaped $sourcefsescaped\#$newsyncsnapescaped");
+				$bookmarksuffix = "$sshcmd $sourcehost " . escapeshellparam("$sourcesudocmd $zfscmd get guid -o value -H $sourcefsescaped\@$newsyncsnapescaped | cksum | cut -d' ' -f1)"; #I don't know how those quotes should be properly escaped in perl
+				$bookmarkcmd = "$sshcmd $sourcehost " . escapeshellparam("$sourcesudocmd $zfscmd bookmark $sourcefsescaped\@$newsyncsnapescaped $sourcefsescaped\#$newsyncsnapescaped-$bookmarksuffix");
 			} else {
-				$bookmarkcmd = "$sourcesudocmd $zfscmd bookmark $sourcefsescaped\@$newsyncsnapescaped $sourcefsescaped\#$newsyncsnapescaped";
+				$bookmarksuffix = "$sourcesudocmd $zfscmd get guid -o value -H $sourcefsescaped\@$newsyncsnapescaped | cksum | cut -d' ' -f1";
+				$bookmarkcmd = "$sourcesudocmd $zfscmd bookmark $sourcefsescaped\@$newsyncsnapescaped $sourcefsescaped\#$newsyncsnapescaped-$bookmarksuffix";
 			}
 			if ($debug) { print "DEBUG: $bookmarkcmd\n"; }
 			system($bookmarkcmd) == 0 or do {
-				warn "CRITICAL ERROR: $bookmarkcmd failed: $?";
-				if ($exitcode < 2) { $exitcode = 2; }
-				return 0;
+				if (!$quiet) { print "INFO: bookmark creation failed, bookmark already exists or bookmark feature is not enabled\n"; }
+				if ($debug) { print "DEBUG: $bookmarkcmd failed: $?"; }
 			};
 		}
 	} else {


### PR DESCRIPTION
when creating bookmarks, currently we copy the snapshot name to the bookmark name

but if user has manually created snapshots or manually created bookmarks, we must not create bookmark if one exists with the same name, by appending the cksum of the guid to the bookmark name (using cksum instead of something else, to get a shorter name. low probability cksum collision should be caught up by user watching syncoid output - bad luck...)

furthermore the user could recycle snapshot names when manually create snapshots, thus resulting in total different guids and point in time representation of those snapshots, so each one gets it's own unique associated bookmark based on it's guid

if bookmark already exists, print informative message about failed creation - there is nothing more we can do...